### PR TITLE
deps: limit pg-protocol deps version to 1.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "p-defer": "^4.0.0",
     "pg": "^8.11.3",
     "pg-cursor": "^2.10.3",
-    "pg-protocol": "^1.9.5",
+    "pg-protocol": "1.8.0",
     "pg-types": "^4.0.2",
     "postgres-array": "^3.0.2",
     "postgres-interval": "^4.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: ^2.10.3
         version: 2.14.1(pg@8.15.1(pg-native@3.4.0))
       pg-protocol:
-        specifier: ^1.9.5
-        version: 1.9.5
+        specifier: 1.8.0
+        version: 1.8.0
       pg-types:
         specifier: ^4.0.2
         version: 4.0.2
@@ -3235,6 +3235,9 @@ packages:
     peerDependencies:
       pg: '>=8.0'
 
+  pg-protocol@1.8.0:
+    resolution: {integrity: sha512-jvuYlEkL03NRvOoyoRktBK7+qU5kOvlAwvmrH8sr3wbLrOdVWsRxQfz8mMy9sZFsqJ1hEWNfdWKI4SAmoL+j7g==}
+
   pg-protocol@1.9.5:
     resolution: {integrity: sha512-DYTWtWpfd5FOro3UnAfwvhD8jh59r2ig8bPtc9H8Ds7MscE/9NYruUQWFAOuraRl29jwcT2kyMFQ3MxeaVjUhg==}
 
@@ -4972,7 +4975,7 @@ snapshots:
   '@types/pg@8.11.13':
     dependencies:
       '@types/node': 22.14.1
-      pg-protocol: 1.9.5
+      pg-protocol: 1.8.0
       pg-types: 4.0.2
 
   '@types/semver@7.7.0': {}
@@ -7854,6 +7857,8 @@ snapshots:
   pg-pool@3.9.1(pg@8.15.1(pg-native@3.4.0)):
     dependencies:
       pg: 8.15.1(pg-native@3.4.0)
+
+  pg-protocol@1.8.0: {}
 
   pg-protocol@1.9.5: {}
 


### PR DESCRIPTION
This PR pins the `pg-protocol` dependency to version 1.8.0. Starting from ^1.9.0, the package introduces exports field entries, which can cause resolution issues in certain environments. To prevent potential breakage, especially in Logto's Azure Functions, we’ve explicitly limited the version to 1.8.0.
