### PR TITLE
Allow URL encoded host in parseDSN

### DIFF
--- a/src/utilities/parseDsn.ts
+++ b/src/utilities/parseDsn.ts
@@ -22,7 +22,7 @@ export const parseDsn = (dsn: string): ConnectionOptions => {
   const connectionOptions: ConnectionOptions = {};
 
   if (url.host) {
-    connectionOptions.host = url.hostname;
+    connectionOptions.host = decodeURIComponent(url.hostname);
   }
 
   if (url.port) {

--- a/test/slonik/utilities/parseDsn.ts
+++ b/test/slonik/utilities/parseDsn.ts
@@ -45,3 +45,9 @@ test('postgresql://fo%2Fo:b%2Far@localhost/ba%2Fz', testParse, {
   password: 'b/ar',
   username: 'fo/o',
 });
+test('postgresql://db_user:db_password@%2Fcloudsql%2Fproject-id%3Aregion-id1%3Acloudsqlinstance-name/dbname', testParse, {
+  databaseName: 'dbname',
+  host: '/cloudsql/project-id:region-id1:cloudsqlinstance-name',
+  password: 'db_password',
+  username: 'db_user',
+});


### PR DESCRIPTION
Manually adding the upstream Slonik patch from 31.2.1 to decode hostnames to fix Unix socket support.

Originally fixed in https://github.com/gajus/slonik/pull/409

Fixes https://github.com/logto-io/logto/issues/7916#issuecomment-3471554242